### PR TITLE
Sort import order per Google's style guide

### DIFF
--- a/feedgen_hasname.py
+++ b/feedgen_hasname.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python3
 
 from concurrent.futures import ThreadPoolExecutor
-from requests_futures.sessions import FuturesSession
-
-import base36
-import bottle
 import configparser
-import feedgen.feed
 import html
-import lxml.html
 import json
 import os
 import re
-import requests
-import sentry_sdk
 import urllib
+
+import base36
+import bottle
+import feedgen.feed
+import lxml.html
+import requests
+from requests_futures.sessions import FuturesSession
+import sentry_sdk
 
 # Variables
 user_agent = "Mozilla/5.0"


### PR DESCRIPTION
Builtins come first, then 3rd parties.

Ref; https://google.github.io/styleguide/pyguide.html#313-imports-formatting